### PR TITLE
BV2-42 (Feat) : Image Id 생성 구현

### DIFF
--- a/global/src/main/java/global/utils/CipherUtils.java
+++ b/global/src/main/java/global/utils/CipherUtils.java
@@ -1,0 +1,37 @@
+package global.utils;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CipherUtils {
+
+    private static final String ALGORITHM = "AES";
+
+    @Value("${cipher.key}")
+    private String key;
+
+    public String encrypt(String plainText) throws Exception {
+        byte[] decodedKey = Base64.getDecoder().decode(key);
+        SecretKeySpec secretKey = new SecretKeySpec(decodedKey, ALGORITHM);
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+        byte[] encryptedText = cipher.doFinal(plainText.getBytes());
+        return Base64.getEncoder().encodeToString(encryptedText);
+    }
+
+    public String decrypt(String encryptedText) throws Exception {
+        byte[] decodedKey = Base64.getDecoder().decode(key);
+        SecretKeySpec secretKey = new SecretKeySpec(decodedKey, ALGORITHM);
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.DECRYPT_MODE, secretKey);
+        byte[] decryptedData = cipher.doFinal(Base64.getDecoder().decode(encryptedText));
+        return new String(decryptedData);
+    }
+
+}

--- a/global/src/main/java/global/utils/ImageUtils.java
+++ b/global/src/main/java/global/utils/ImageUtils.java
@@ -1,0 +1,32 @@
+package global.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ImageUtils {
+
+    private final CipherUtils cipherUtils;
+
+    // TODO 예외 처리
+    public String generateImageId(String module, String userId) {
+         String imageId = module + "-" + userId + "-" + System.nanoTime();
+        try {
+            return cipherUtils.encrypt(imageId);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // TODO 예외 처리
+    public String decodeImageId(String imageId) {
+        try {
+            return cipherUtils.decrypt(imageId);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}
+

--- a/global/src/main/resources/application.yml
+++ b/global/src/main/resources/application.yml
@@ -1,5 +1,3 @@
-
-
 spring:
   application:
     name: baobab-global
@@ -32,3 +30,6 @@ logging:
 log:
   config:
     path: logs
+
+cipher:
+  key: ABO6jnQHzqrupXWDW5HyHXOD+FZA1gYLNgqFdPge/tg=

--- a/global/src/test/java/global/utils/CipherUtilsTest.java
+++ b/global/src/test/java/global/utils/CipherUtilsTest.java
@@ -1,0 +1,41 @@
+package global.utils;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+class CipherUtilsTest {
+
+    @Autowired
+    private CipherUtils cipherUtils;
+
+    @Test
+    void generateImageId() {
+        String plainText = "ART-" + "123456fdsaf562342-" + System.nanoTime();
+        String imageId = null;
+
+        try {
+            imageId = cipherUtils.encrypt(plainText);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        assertNotNull(imageId); // 결과가 null이 아닌지 확인
+
+        String decodeId = null;
+
+        try {
+            decodeId = cipherUtils.decrypt(imageId);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        assertNotNull(decodeId); // 결과가 null이 아닌지 확인
+        assertEquals(plainText, decodeId); // 평문과 복호화된 값과 같은지 확인
+
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

N/A

## 📝 요약(Summary)
- 암호화 · 복호화 Util 구현
- 이미지 Util 구현
- 암호화 · 복호화 테스트

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
원래 암호화를 사용하지 않고 이미지 아이디에 Base64 인코딩만 할 예정이었으나 
유저 아이디에 어떻게 Salt 값을 넣을 것인가 고민했습니다.
유저 아이디에 Salt를 부분적으로 넣으려고 했으나 여러 유저 아이디를 취합하면 패턴이 보이는 문제가 발생할 것 같아
대칭키 암호화 알고리즘인 AES-256을 사용했으며 테스트를 통해 암호화, 복호화 검증을 진행했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)