### PR TITLE
BV2-69 (Feat) : KST Converter 구현

### DIFF
--- a/global/src/main/java/global/converter/KSTConverter.java
+++ b/global/src/main/java/global/converter/KSTConverter.java
@@ -1,0 +1,22 @@
+package global.converter;
+
+import global.annotation.Converter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Converter
+public class KSTConverter {
+
+    private static final int KST_OFFSET_HOURS = 9;
+
+    private static final DateTimeFormatter KST_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+
+    public String convertToKST(LocalDateTime localDateTime) {
+
+        LocalDateTime dateTime = localDateTime.plusHours(KST_OFFSET_HOURS);
+
+        return dateTime.format(KST_FORMATTER);
+
+    }
+
+}

--- a/global/src/test/java/global/converter/KSTConverterTest.java
+++ b/global/src/test/java/global/converter/KSTConverterTest.java
@@ -1,0 +1,23 @@
+package global.converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class KSTConverterTest {
+
+    @Test
+    void convertToKST() {
+
+        KSTConverter converter = new KSTConverter();
+
+        LocalDateTime utcDateTime = LocalDateTime.of(2025, 1, 15, 0, 0, 0);
+
+        String expectedKST = "2025-01-15T09:00:00.000";
+
+        String result = converter.convertToKST(utcDateTime);
+
+        assertEquals(expectedKST, result);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
N/A

## 📝 요약(Summary)
- 몽고DB에 대한민국 표준시(KST)로 시간을 저장할 수 있도록 Converter를 구현했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
대한민국 표준시(KST)로 저장될 수 있게 LocalDateTime에 9시간을 더하려고 했지만
마지막에 시간대 지정자 Z가 붙어 UTC로 착각할 수 있어 포맷 지정까지 했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)