### PR TITLE
BV2-79 (fix): 이미지 삭제 시 url이 유효하지 않는 버그 해결

### DIFF
--- a/file/src/main/java/file/core/LocalFileAndDBImageStorageService.java
+++ b/file/src/main/java/file/core/LocalFileAndDBImageStorageService.java
@@ -6,10 +6,13 @@ import file.core.common.exception.image.ImageStorageException;
 import file.domain.ImageMetaData;
 import file.domain.ImageCommand;
 import lombok.RequiredArgsConstructor;
+import org.apache.hc.core5.net.URIBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -22,6 +25,8 @@ public class LocalFileAndDBImageStorageService implements ImageStorageUseCase {
     private final LocalFileStorageService fileStorageService;
     private final MongoDBImageMetaDataService imageMetaDataService;
     private final ApplicationContext context;
+    @Value("${file.upload-dir}")
+    private String uploadDir;
 
     @Async
     @Transactional
@@ -72,7 +77,8 @@ public class LocalFileAndDBImageStorageService implements ImageStorageUseCase {
 
         String imageUrl = imageMetaDataService.deleteImage(imageId);
         Path path = Path.of(URI.create(imageUrl).getPath());
-        fileStorageService.deleteImage(path);
+        Path filePath = Path.of(uploadDir, path.getFileName().toString());
+        fileStorageService.deleteImage(filePath);
     }
 
     @Override

--- a/file/src/main/java/file/core/MongoDBImageMetaDataService.java
+++ b/file/src/main/java/file/core/MongoDBImageMetaDataService.java
@@ -61,7 +61,7 @@ public class MongoDBImageMetaDataService {
     private String createImageUrl(Path filePath) {
         return ServletUriComponentsBuilder.fromCurrentContextPath()
                 .scheme("http")
-                .path(dir + filePath.getFileName())
+                .path(dir + "/" + filePath.getFileName())
                 .toUriString();
     }
 }

--- a/file/src/main/resources/application.yaml
+++ b/file/src/main/resources/application.yaml
@@ -46,5 +46,5 @@ log:
 
 file:
   upload-dir: file/src/main/resources/images
-  dir: images/
+  dir: images
 


### PR DESCRIPTION
BV2-79 (fix): 이미지 삭제 시 url이 유효하지 않는 버그 해결

1. DB에 저장되는 URL 중 Path 값 : images/{fileName} (컨텍스트 패스)
2. 파일스토리지 속 이미지 삭제할떄 필요한 Path 값 : file/src/main/resources/images/{fileName} (파일 경로)
3. DB에서 이미지 삭제 후 반환받는 url에서 path를 가져와 path에서 컨텍스트 패스를 파일 경로로 바꾸는 기능 수행

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



