### PR TITLE
BV2-86 (fix): LocalDateTime registeredAt 조회 시 배열로 출력되는 버그 해결

### DIFF
--- a/file/src/main/java/file/core/config/WebConfig.java
+++ b/file/src/main/java/file/core/config/WebConfig.java
@@ -3,10 +3,10 @@ package file.core.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebConfig extends WebMvcConfigurationSupport {
+public class WebConfig implements WebMvcConfigurer {
     @Value("${file.upload-dir}")
     private String uploadDir;
 


### PR DESCRIPTION
BV2-86 (fix): LocalDateTime registeredAt 조회 시 배열로 출력되는 버그 해결

1. Json 형식으로 본 LocalDateTime 데이터가 배열 형식으로 변환됨을 확인
"registeredAt": "2025-01-16T01:29:45.786" ->
"registeredAt": [
            2025,
            1,
            16,
            1,
            29,
            45,
            786000000
        ]
2. WebMvcConfigurationSupport는 웹 애플리케이션의 설정을 관리하지만, 기본적으로 LocalDateTime과 같은 날짜/시간 객체를 직렬화할 때 타임스탬프(숫자 형식) 또는 배열 형식으로 변환
3. WebMvcConfigurationSupport -> WebMvcConfigurer 로 변경
4. WebMvcConfigurer는 Spring Boot의 자동 설정이 활성화되며, ObjectMapper의 기본 설정이 제대로 적용되기 때문에 LocalDateTime과 같은 날짜/시간 타입을 자동으로 문자열로 직렬화 수행

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



