### PR TITLE
BV2-115 (Refactor) : 사용자 정보 수정 로직 수정

### DIFF
--- a/user/src/main/java/user/adapter/input/web/UserApiController.java
+++ b/user/src/main/java/user/adapter/input/web/UserApiController.java
@@ -41,7 +41,7 @@ public class UserApiController {
         @RequestPart("profileImage") MultipartFile profileImage,
         @AuthenticatedUser AuthUser authUser
     ) {
-        UserUpdateCommand updateCommand = UserUpdateCommand.toCommand(
+        UserUpdateCommand updateCommand = UserUpdateCommand.of(
             userUpdateRequest.getBody(), profileImage, authUser.getUserId());
 
         boolean isUpdated = userUpdateUseCase.updateUserInfo(updateCommand);
@@ -54,7 +54,7 @@ public class UserApiController {
         @RequestBody @Valid Api<UserUnRegisterRequest> userUnRegisterRequest,
         @AuthenticatedUser AuthUser authUser
     ) {
-        UserUnRegisterCommand unRegisterCommand = UserUnRegisterCommand.toCommand(
+        UserUnRegisterCommand unRegisterCommand = UserUnRegisterCommand.of(
             userUnRegisterRequest.getBody(), authUser.getUserId());
 
         boolean isUnRegistered = userUnRegisterUseCase.unRegister(unRegisterCommand);

--- a/user/src/main/java/user/adapter/input/web/UserOpenApiController.java
+++ b/user/src/main/java/user/adapter/input/web/UserOpenApiController.java
@@ -39,7 +39,7 @@ public class UserOpenApiController {
     public Api<UserRegisterResponse> register(
         @RequestBody @Valid Api<UserRegisterRequest> userRegisterRequest
     ) {
-        UserRegisterCommand registerCommand = UserRegisterCommand.toCommand(
+        UserRegisterCommand registerCommand = UserRegisterCommand.of(
             userRegisterRequest.getBody());
 
         String userId = userRegisterUseCase.register(registerCommand);
@@ -49,7 +49,7 @@ public class UserOpenApiController {
 
     @PostMapping("/login")
     public Api<TokenResponse> login(@RequestBody @Valid Api<UserLoginRequest> userLoginRequest) {
-        UserLoginCommand loginCommand = UserLoginCommand.toCommand(userLoginRequest.getBody());
+        UserLoginCommand loginCommand = UserLoginCommand.of(userLoginRequest.getBody());
         TokenCommand tokenCommand = userLoginUseCase.login(loginCommand);
         TokenResponse response = TokenResponse.toResponse(tokenCommand);
         return Api.OK(response);

--- a/user/src/main/java/user/adapter/output/persistence/UserPersistenceAdapter.java
+++ b/user/src/main/java/user/adapter/output/persistence/UserPersistenceAdapter.java
@@ -33,7 +33,7 @@ public class UserPersistenceAdapter implements UserPersistencePort {
 
     @Override
     public String saveUser(UserRegisterForm userRegisterForm) {
-        UserDocument user = UserDocument.toUserDocument(userRegisterForm);
+        UserDocument user = UserDocument.of(userRegisterForm);
         UserDocument savedUser = userMongoRepository.save(user);
         return savedUser.getId();
     }
@@ -48,10 +48,7 @@ public class UserPersistenceAdapter implements UserPersistencePort {
 
     @Override
     public boolean updateUser(UserUpdateForm userUpdateForm) {
-        UserDocument userDocument = getUserDocument(userUpdateForm.getUserId(),
-            UserStatus.REGISTERED);
-
-        UserDocument updatedDocument = UserDocument.toUserDocument(userUpdateForm, userDocument);
+        UserDocument updatedDocument = UserDocument.of(userUpdateForm);
         UserDocument savedUser = userMongoRepository.save(updatedDocument);
         return savedUser.getId() != null;
     }

--- a/user/src/main/java/user/adapter/output/persistence/UserPersistenceAdapter.java
+++ b/user/src/main/java/user/adapter/output/persistence/UserPersistenceAdapter.java
@@ -83,7 +83,7 @@ public class UserPersistenceAdapter implements UserPersistencePort {
     public UserReaderCommand getUserInfo(String userId, UserStatus status) {
         UserDocument user = userMongoRepository.findFirstByIdAndStatusOrderByIdDesc(userId, status)
             .orElseThrow(() -> new UserNotFoundException(UserErrorCode.USER_NOT_FOUND));
-        return UserReaderCommand.toCommand(user);
+        return UserReaderCommand.of(user);
     }
 
     @Override

--- a/user/src/main/java/user/adapter/output/persistence/repository/UserDocument.java
+++ b/user/src/main/java/user/adapter/output/persistence/repository/UserDocument.java
@@ -44,23 +44,23 @@ public class UserDocument {
 
     private Address address;
 
-    public static UserDocument toUserDocument(UserUpdateForm userUpdateForm, UserDocument userDocument) {
+    public static UserDocument of(UserUpdateForm userUpdateForm) {
         return UserDocument.builder()
-            .id(userDocument.getId())
+            .id(userUpdateForm.getUserId())
             .nickName(userUpdateForm.getNickName())
             .phone(userUpdateForm.getPhone())
             .department(userUpdateForm.getDepartment())
             .birth(userUpdateForm.getBirth())
             .profileImage(userUpdateForm.getProfileImage())
-            .role(userDocument.getRole())
+            .role(userUpdateForm.getRole())
             .status(UserStatus.REGISTERED)
-            .registeredAt(userDocument.getRegisteredAt())
-            .unRegisteredAt(userDocument.getUnRegisteredAt())
-            .lastLoginAt(userDocument.getLastLoginAt())
+            .registeredAt(userUpdateForm.getRegisteredAt())
+            .unRegisteredAt(userUpdateForm.getUnRegisteredAt())
+            .lastLoginAt(userUpdateForm.getLastLoginAt())
             .account(
                 Account.builder()
-                    .email(userDocument.getAccount().getEmail())
-                    .password(userDocument.getAccount().getPassword())
+                    .email(userUpdateForm.getEmail())
+                    .password(userUpdateForm.getPassword())
                     .name(userUpdateForm.getName())
                     .build()
             )
@@ -75,7 +75,7 @@ public class UserDocument {
             .build();
     }
 
-    public static UserDocument toUserDocument(UserRegisterForm userRegisterForm) {
+    public static UserDocument of(UserRegisterForm userRegisterForm) {
         return UserDocument.builder()
             .nickName(userRegisterForm.getNickName())
             .phone(userRegisterForm.getPhone())

--- a/user/src/main/java/user/application/UserRegisterService.java
+++ b/user/src/main/java/user/application/UserRegisterService.java
@@ -32,7 +32,7 @@ public class UserRegisterService implements UserRegisterUseCase {
     }
 
     private UserRegisterForm initUserParameter(UserRegisterCommand userRegisterCommand) {
-        return UserRegisterForm.toForm(userRegisterCommand);
+        return UserRegisterForm.of(userRegisterCommand);
     }
 
     private ProfileImage saveProfileImage(String userId, MultipartFile profileImage) {

--- a/user/src/main/java/user/application/UserUnRegisterService.java
+++ b/user/src/main/java/user/application/UserUnRegisterService.java
@@ -18,7 +18,7 @@ public class UserUnRegisterService implements UserUnRegisterUseCase {
     @Override
     public boolean unRegister(UserUnRegisterCommand userUnRegisterCommand) {
 
-        UserUnRegisterForm unRegisterForm = UserUnRegisterForm.toForm(
+        UserUnRegisterForm unRegisterForm = UserUnRegisterForm.of(
             userUnRegisterCommand.getUserId());
 
         return userPersistencePort.unRegisterUser(unRegisterForm);

--- a/user/src/main/java/user/application/UserUpdateService.java
+++ b/user/src/main/java/user/application/UserUpdateService.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import user.adapter.output.persistence.enums.UserStatus;
+import user.adapter.output.persistence.repository.UserDocument;
 import user.application.port.input.UserUpdateUseCase;
 import user.application.port.output.UserPersistencePort;
 import user.domain.command.UserUpdateCommand;
@@ -25,11 +27,16 @@ public class UserUpdateService implements UserUpdateUseCase {
     @Override
     public boolean updateUserInfo(UserUpdateCommand userUpdateCommand) {
 
+        UserDocument userDocument = userPersistenceAdapter.getUserDocument(
+            userUpdateCommand.getUserId(), UserStatus.REGISTERED);
+
         ProfileImage profileImage = saveProfileImage(userUpdateCommand.getUserId(),
             userUpdateCommand.getProfileImage());
         deleteProfileImage(userUpdateCommand);
 
-        UserUpdateForm userUpdateForm = UserUpdateForm.toForm(userUpdateCommand, profileImage);
+        userDocument.setProfileImage(profileImage);
+
+        UserUpdateForm userUpdateForm = UserUpdateForm.toForm(userUpdateCommand, userDocument);
         return userPersistenceAdapter.updateUser(userUpdateForm);
     }
 

--- a/user/src/main/java/user/domain/command/TokenCommand.java
+++ b/user/src/main/java/user/domain/command/TokenCommand.java
@@ -1,10 +1,8 @@
 package user.domain.command;
 
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import user.security.jwt.model.TokenDto;
 
 @Data
@@ -19,7 +17,7 @@ public class TokenCommand {
 
     private LocalDateTime refreshTokenExpiredAt;
 
-    public static TokenCommand toCommand(TokenDto accessToken, TokenDto refreshToken) {
+    public static TokenCommand of(TokenDto accessToken, TokenDto refreshToken) {
         return TokenCommand.builder()
             .accessToken(accessToken.getToken())
             .accessTokenExpiredAt(accessToken.getExpiredAt())

--- a/user/src/main/java/user/domain/command/UserLoginCommand.java
+++ b/user/src/main/java/user/domain/command/UserLoginCommand.java
@@ -12,7 +12,7 @@ public class UserLoginCommand {
 
     private String password;
 
-    public static UserLoginCommand toCommand(UserLoginRequest userLoginRequest) {
+    public static UserLoginCommand of(UserLoginRequest userLoginRequest) {
         return UserLoginCommand.builder()
             .email(userLoginRequest.getEmail())
             .password(userLoginRequest.getPassword())

--- a/user/src/main/java/user/domain/command/UserReaderCommand.java
+++ b/user/src/main/java/user/domain/command/UserReaderCommand.java
@@ -49,25 +49,25 @@ public class UserReaderCommand {
 
     private LocalDateTime lastLoginAt;
 
-    public static UserReaderCommand toCommand(UserDocument user) {
+    public static UserReaderCommand of(UserDocument userDocument) {
         return UserReaderCommand.builder()
-            .userId(user.getId())
-            .email(user.getAccount().getEmail())
-            .nickName(user.getNickName())
-            .name(user.getAccount().getName())
-            .phone(user.getPhone())
-            .department(user.getDepartment())
-            .birth(user.getBirth())
-            .address(user.getAddress().getAddress())
-            .detailAddress(user.getAddress().getDetailAddress())
-            .basicAddress(user.getAddress().getBasicAddress())
-            .post(user.getAddress().getPost())
-            .profileImage(user.getProfileImage())
-            .role(user.getRole())
-            .status(user.getStatus())
-            .registeredAt(user.getRegisteredAt())
-            .unRegisteredAt(user.getUnRegisteredAt())
-            .lastLoginAt(user.getLastLoginAt())
+            .userId(userDocument.getId())
+            .email(userDocument.getAccount().getEmail())
+            .nickName(userDocument.getNickName())
+            .name(userDocument.getAccount().getName())
+            .phone(userDocument.getPhone())
+            .department(userDocument.getDepartment())
+            .birth(userDocument.getBirth())
+            .address(userDocument.getAddress().getAddress())
+            .detailAddress(userDocument.getAddress().getDetailAddress())
+            .basicAddress(userDocument.getAddress().getBasicAddress())
+            .post(userDocument.getAddress().getPost())
+            .profileImage(userDocument.getProfileImage())
+            .role(userDocument.getRole())
+            .status(userDocument.getStatus())
+            .registeredAt(userDocument.getRegisteredAt())
+            .unRegisteredAt(userDocument.getUnRegisteredAt())
+            .lastLoginAt(userDocument.getLastLoginAt())
             .build();
     }
 

--- a/user/src/main/java/user/domain/command/UserRegisterCommand.java
+++ b/user/src/main/java/user/domain/command/UserRegisterCommand.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import user.adapter.input.web.request.UserRegisterRequest;
 import user.adapter.output.persistence.enums.UserRole;
 import user.adapter.output.persistence.enums.UserStatus;
-import user.domain.dto.ProfileImage;
 
 @Data
 @Builder
@@ -45,7 +44,7 @@ public class UserRegisterCommand {
 
     private LocalDateTime registeredAt;
 
-    public static UserRegisterCommand toCommand(UserRegisterRequest userRegisterRequest) {
+    public static UserRegisterCommand of(UserRegisterRequest userRegisterRequest) {
         return UserRegisterCommand.builder()
             .email(userRegisterRequest.getEmail())
             .password(userRegisterRequest.getPassword())

--- a/user/src/main/java/user/domain/command/UserUnRegisterCommand.java
+++ b/user/src/main/java/user/domain/command/UserUnRegisterCommand.java
@@ -12,7 +12,7 @@ public class UserUnRegisterCommand {
 
     private String password;
 
-    public static UserUnRegisterCommand toCommand(
+    public static UserUnRegisterCommand of(
         UserUnRegisterRequest userUnRegisterRequest, String userId
     ) {
         return UserUnRegisterCommand.builder()

--- a/user/src/main/java/user/domain/command/UserUpdateCommand.java
+++ b/user/src/main/java/user/domain/command/UserUpdateCommand.java
@@ -1,12 +1,10 @@
 package user.domain.command;
 
-import file.domain.ImageMetaData;
 import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.web.multipart.MultipartFile;
 import user.adapter.input.web.request.UserUpdateRequest;
-import user.domain.dto.ProfileImage;
 
 @Data
 @Builder
@@ -36,7 +34,7 @@ public class UserUpdateCommand {
 
     private String deleteImageId;
 
-    public static UserUpdateCommand toCommand(
+    public static UserUpdateCommand of(
         UserUpdateRequest userUpdateRequest, MultipartFile profileImage, String userId
     ) {
         return UserUpdateCommand.builder()

--- a/user/src/main/java/user/domain/dto/UserRegisterForm.java
+++ b/user/src/main/java/user/domain/dto/UserRegisterForm.java
@@ -2,10 +2,8 @@ package user.domain.dto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.mindrot.jbcrypt.BCrypt;
 import user.adapter.output.persistence.enums.UserRole;
 import user.adapter.output.persistence.enums.UserStatus;
@@ -43,7 +41,7 @@ public class UserRegisterForm {
 
     private LocalDateTime registeredAt;
 
-    public static UserRegisterForm toForm(UserRegisterCommand userRegisterCommand) {
+    public static UserRegisterForm of(UserRegisterCommand userRegisterCommand) {
         return UserRegisterForm.builder()
             .email(userRegisterCommand.getEmail())
             .encodingPassword(

--- a/user/src/main/java/user/domain/dto/UserUnRegisterForm.java
+++ b/user/src/main/java/user/domain/dto/UserUnRegisterForm.java
@@ -19,7 +19,7 @@ public class UserUnRegisterForm {
 
     private LocalDateTime unRegisterAt;
 
-    public static UserUnRegisterForm toForm(String userId) {
+    public static UserUnRegisterForm of(String userId) {
         return UserUnRegisterForm.builder()
             .userId(userId)
             .status(UserStatus.UNREGISTERED)

--- a/user/src/main/java/user/domain/dto/UserUpdateForm.java
+++ b/user/src/main/java/user/domain/dto/UserUpdateForm.java
@@ -1,8 +1,14 @@
 package user.domain.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Data;
+import user.adapter.output.persistence.enums.UserRole;
+import user.adapter.output.persistence.enums.UserStatus;
+import user.adapter.output.persistence.repository.Account;
+import user.adapter.output.persistence.repository.Address;
+import user.adapter.output.persistence.repository.UserDocument;
 import user.domain.command.UserUpdateCommand;
 
 @Data
@@ -10,6 +16,10 @@ import user.domain.command.UserUpdateCommand;
 public class UserUpdateForm {
 
     private String userId;
+
+    private String email;
+
+    private String password;
 
     private String name;
 
@@ -31,9 +41,21 @@ public class UserUpdateForm {
 
     private String post;
 
-    public static UserUpdateForm toForm(UserUpdateCommand userUpdateCommand, ProfileImage profileImage) {
+    private UserRole role;
+
+    private UserStatus status;
+
+    private LocalDateTime registeredAt;
+
+    private LocalDateTime unRegisteredAt;
+
+    private LocalDateTime lastLoginAt;
+
+    public static UserUpdateForm toForm(UserUpdateCommand userUpdateCommand, UserDocument userDocument) {
         return UserUpdateForm.builder()
             .userId(userUpdateCommand.getUserId())
+            .email(userDocument.getAccount().getEmail())
+            .password(userDocument.getAccount().getPassword())
             .nickName(userUpdateCommand.getNickName())
             .name(userUpdateCommand.getName())
             .phone(userUpdateCommand.getPhone())
@@ -43,7 +65,12 @@ public class UserUpdateForm {
             .detailAddress(userUpdateCommand.getDetailAddress())
             .basicAddress(userUpdateCommand.getBasicAddress())
             .post(userUpdateCommand.getPost())
-            .profileImage(profileImage)
+            .role(userDocument.getRole())
+            .status(userDocument.getStatus())
+            .registeredAt(userDocument.getRegisteredAt())
+            .unRegisteredAt(userDocument.getUnRegisteredAt())
+            .lastLoginAt(userDocument.getLastLoginAt())
+            .profileImage(userDocument.getProfileImage())
             .build();
     }
 

--- a/user/src/main/java/user/domain/dto/UserUpdateForm.java
+++ b/user/src/main/java/user/domain/dto/UserUpdateForm.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import user.adapter.output.persistence.enums.UserRole;
 import user.adapter.output.persistence.enums.UserStatus;
-import user.adapter.output.persistence.repository.Account;
-import user.adapter.output.persistence.repository.Address;
 import user.adapter.output.persistence.repository.UserDocument;
 import user.domain.command.UserUpdateCommand;
 

--- a/user/src/main/java/user/security/jwt/service/TokenIssueService.java
+++ b/user/src/main/java/user/security/jwt/service/TokenIssueService.java
@@ -26,7 +26,7 @@ public class TokenIssueService {
             tokenHelperService.deleteRefreshToken(dto.getUserId());
             tokenHelperService.saveRefreshToken(dto.getUserId(), refreshToken.getToken());
 
-            return TokenCommand.toCommand(accessToken, refreshToken);
+            return TokenCommand.of(accessToken, refreshToken);
 
         }).orElseThrow(() -> new TokenException(ErrorCode.NULL_POINT));
     }


### PR DESCRIPTION
## #️⃣ Issue Number

N/A

## 📝 요약(Summary)

- `PersistenceAdapter` 의 `updateUser` 메서드는 `update` 책임만 갖도록 변경
- `.toXXX()` -> `.of()` 로 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



