### PR TITLE
BV2-173 (Feat) : 채팅 메시지 저장 개발 

### DIFF
--- a/chat/src/main/java/chat/adapter/output/ChatMessagePersistenceAdapter.java
+++ b/chat/src/main/java/chat/adapter/output/ChatMessagePersistenceAdapter.java
@@ -1,0 +1,23 @@
+package chat.adapter.output;
+
+import chat.adapter.output.persistence.repository.MessageMongoRepository;
+import chat.adapter.output.persistence.repository.document.MessageDocument;
+import chat.application.port.output.ChatMessagePersistencePort;
+import chat.domain.dto.ChatMessageSaveForm;
+import global.annotation.output.PersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ChatMessagePersistenceAdapter implements ChatMessagePersistencePort {
+
+    private final MessageMongoRepository messageMongoRepository;
+
+    @Override
+    public boolean saveMessage(ChatMessageSaveForm chatMessageSaveForm) {
+        MessageDocument savedMessage = messageMongoRepository.save(
+            MessageDocument.of(chatMessageSaveForm));
+        return savedMessage.getId() != null;
+    }
+
+}

--- a/chat/src/main/java/chat/adapter/output/persistence/repository/document/MessageDocument.java
+++ b/chat/src/main/java/chat/adapter/output/persistence/repository/document/MessageDocument.java
@@ -1,6 +1,7 @@
 package chat.adapter.output.persistence.repository.document;
 
 import chat.adapter.output.persistence.enums.MessageType;
+import chat.domain.dto.ChatMessageSaveForm;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,10 +24,20 @@ public class MessageDocument {
 
     private MessageType messageType;
 
-    private LocalDateTime sendAt;
+    @Builder.Default
+    private LocalDateTime sendAt = LocalDateTime.now();
 
-    private Boolean isRead;
+    @Builder.Default
+    private Boolean isRead = false;
 
-    private String chatId;
+    private String chatRoomId;
+
+    public static MessageDocument of(ChatMessageSaveForm chatMessageSaveForm) {
+        return MessageDocument.builder()
+            .message(chatMessageSaveForm.getMessage())
+            .messageType(chatMessageSaveForm.getMessageType())
+            .chatRoomId(chatMessageSaveForm.getChatRoomId())
+            .build();
+    }
 
 }

--- a/chat/src/main/java/chat/application/ChatMessagePublishService.java
+++ b/chat/src/main/java/chat/application/ChatMessagePublishService.java
@@ -1,0 +1,20 @@
+package chat.application;
+
+import chat.application.port.input.ChatMessageSaveUseCase;
+import chat.domain.command.ChatMessagePublishCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessagePublishService {
+
+    private final ChatMessageSaveUseCase chatMessageSaveUseCase;
+
+    public boolean publishMessage(ChatMessagePublishCommand command) {
+        chatMessageSaveUseCase.saveChatMessage(command);
+
+        return true;
+    }
+
+}

--- a/chat/src/main/java/chat/application/ChatMessagePublishService.java
+++ b/chat/src/main/java/chat/application/ChatMessagePublishService.java
@@ -1,7 +1,10 @@
 package chat.application;
 
 import chat.application.port.input.ChatMessageSaveUseCase;
+import chat.application.port.input.ChatRoomCheckUseCase;
 import chat.domain.command.ChatMessagePublishCommand;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,9 +13,20 @@ import org.springframework.stereotype.Service;
 public class ChatMessagePublishService {
 
     private final ChatMessageSaveUseCase chatMessageSaveUseCase;
+    private final ChatRoomCheckUseCase chatRoomCheckUseCase;
 
     public boolean publishMessage(ChatMessagePublishCommand command) {
+
+        Optional<String> chatRoomId = chatRoomCheckUseCase.existsChatRoomBy(List.of(command.getChatRoomId()),
+            command.getUserId());
+
+        if (chatRoomId.isEmpty()) {
+            throw new RuntimeException(); // TODO 예외처리
+        }
+
         chatMessageSaveUseCase.saveChatMessage(command);
+
+        // Kafka
 
         return true;
     }

--- a/chat/src/main/java/chat/application/ChatMessageSaveService.java
+++ b/chat/src/main/java/chat/application/ChatMessageSaveService.java
@@ -1,0 +1,21 @@
+package chat.application;
+
+import chat.application.port.input.ChatMessageSaveUseCase;
+import chat.application.port.output.ChatMessagePersistencePort;
+import chat.domain.command.ChatMessagePublishCommand;
+import chat.domain.dto.ChatMessageSaveForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageSaveService implements ChatMessageSaveUseCase {
+
+    private final  ChatMessagePersistencePort chatMessagePersistencePort;
+
+    @Override
+    public boolean saveChatMessage(ChatMessagePublishCommand command) {
+        return chatMessagePersistencePort.saveMessage(ChatMessageSaveForm.of(command));
+    }
+
+}

--- a/chat/src/main/java/chat/application/port/input/ChatMessageSaveUseCase.java
+++ b/chat/src/main/java/chat/application/port/input/ChatMessageSaveUseCase.java
@@ -1,0 +1,9 @@
+package chat.application.port.input;
+
+import chat.domain.command.ChatMessagePublishCommand;
+
+public interface ChatMessageSaveUseCase {
+
+    boolean saveChatMessage(ChatMessagePublishCommand command);
+
+}

--- a/chat/src/main/java/chat/application/port/output/ChatMessagePersistencePort.java
+++ b/chat/src/main/java/chat/application/port/output/ChatMessagePersistencePort.java
@@ -1,0 +1,9 @@
+package chat.application.port.output;
+
+import chat.domain.dto.ChatMessageSaveForm;
+
+public interface ChatMessagePersistencePort {
+
+    boolean saveMessage(ChatMessageSaveForm chatMessageSaveForm);
+
+}

--- a/chat/src/main/java/chat/application/sse/SseConnectionStore.java
+++ b/chat/src/main/java/chat/application/sse/SseConnectionStore.java
@@ -1,0 +1,11 @@
+package chat.application.sse;
+
+public interface SseConnectionStore<T, R> {
+
+    void saveEmitter(T userId, R connection);
+
+    R findEmitter(T userId);
+
+    void deleteEmitter(R connection);
+
+}

--- a/chat/src/main/java/chat/application/sse/SseConnectionStoreImpl.java
+++ b/chat/src/main/java/chat/application/sse/SseConnectionStoreImpl.java
@@ -1,0 +1,27 @@
+package chat.application.sse;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SseConnectionStoreImpl implements SseConnectionStore<String, UserSseConnection> {
+
+    private static final Map<String, UserSseConnection> connectionStore = new ConcurrentHashMap<>();
+
+    @Override
+    public void saveEmitter(String userId, UserSseConnection connection) {
+        connectionStore.put(userId, connection);
+    }
+
+    @Override
+    public UserSseConnection findEmitter(String userId) {
+        return connectionStore.get(userId);
+    }
+
+    @Override
+    public void deleteEmitter(UserSseConnection connection) {
+        connectionStore.remove(connection.getUserId());
+    }
+
+}

--- a/chat/src/main/java/chat/application/sse/SseEmitterManager.java
+++ b/chat/src/main/java/chat/application/sse/SseEmitterManager.java
@@ -1,0 +1,16 @@
+package chat.application.sse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SseEmitterManager {
+
+    private final SseConnectionStore<String, UserSseConnection> sseConnectionStore;
+
+    public UserSseConnection createSseEmitter(String userId) {
+        return UserSseConnection.create(userId, sseConnectionStore);
+    }
+
+}

--- a/chat/src/main/java/chat/application/sse/SseMessageManager.java
+++ b/chat/src/main/java/chat/application/sse/SseMessageManager.java
@@ -1,0 +1,38 @@
+package chat.application.sse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class SseMessageManager {
+
+    private final ObjectMapper objectMapper;
+
+    public void sendMessage(UserSseConnection connection, String eventName, Object data) {
+        send(connection, eventName, data);
+    }
+
+    public void sendMessage(UserSseConnection connection, Object data) {
+        send(connection, null, data);
+    }
+
+
+    public void send(UserSseConnection connection, String eventName, Object data) {
+        try {
+            var json = this.objectMapper.writeValueAsString(data);
+            SseEventBuilder event = SseEmitter.event().data(json);
+            if (eventName != null) {
+                event.name(eventName);
+            }
+            connection.getSseEmitter().send(event);
+        } catch (IOException e) {
+            connection.getSseEmitter().completeWithError(e);
+        }
+    }
+
+}

--- a/chat/src/main/java/chat/application/sse/UserSseConnection.java
+++ b/chat/src/main/java/chat/application/sse/UserSseConnection.java
@@ -1,0 +1,39 @@
+package chat.application.sse;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class UserSseConnection {
+
+    private final String userId;
+    private final SseEmitter sseEmitter;
+    private final SseConnectionStore<String, UserSseConnection> sseConnectionStore;
+
+    private UserSseConnection(
+        String userId,
+        SseConnectionStore<String, UserSseConnection> connectionRegistryPort
+    ){
+        this.userId = userId;
+        this.sseEmitter = new SseEmitter(60 * 1000L * 60); // 1h
+        this.sseConnectionStore = connectionRegistryPort; // call back 초기화
+
+        this.sseEmitter.onCompletion(()->{
+            this.sseConnectionStore.deleteEmitter(this);
+        });
+
+        this.sseEmitter.onTimeout(this.sseEmitter::complete);
+    }
+
+    public static UserSseConnection create(
+        String userId,
+        SseConnectionStore<String, UserSseConnection> connectionRegistryPort
+    ){
+        return new UserSseConnection(userId, connectionRegistryPort);
+    }
+
+}

--- a/chat/src/main/java/chat/domain/command/ChatMessagePublishCommand.java
+++ b/chat/src/main/java/chat/domain/command/ChatMessagePublishCommand.java
@@ -1,0 +1,21 @@
+package chat.domain.command;
+
+import chat.adapter.output.persistence.enums.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ChatMessagePublishCommand {
+
+    private String message;
+
+    private String chatRoomId;
+
+    private String userId;
+
+    private MessageType messageType;
+
+}

--- a/chat/src/main/java/chat/domain/dto/ChatMessageSaveForm.java
+++ b/chat/src/main/java/chat/domain/dto/ChatMessageSaveForm.java
@@ -1,0 +1,31 @@
+package chat.domain.dto;
+
+import chat.adapter.output.persistence.enums.MessageType;
+import chat.domain.command.ChatMessagePublishCommand;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ChatMessageSaveForm {
+
+    private String message;
+
+    private String chatRoomId;
+
+    private String userId;
+
+    private MessageType messageType;
+
+    public static ChatMessageSaveForm of(ChatMessagePublishCommand command) {
+        return ChatMessageSaveForm.builder()
+            .message(command.getMessage())
+            .chatRoomId(command.getChatRoomId())
+            .userId(command.getUserId())
+            .messageType(command.getMessageType())
+            .build();
+
+    }
+}

--- a/chat/src/main/resources/application-local.yml
+++ b/chat/src/main/resources/application-local.yml
@@ -1,6 +1,11 @@
 server:
   port: 0 # 랜덤 포트를 사용하기 위함
 
+  servlet:
+    session:
+      cookie:
+        name: JSESSIONID
+
 spring:
   application:
     name: baobab-chat


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

- 단순 채팅 메시지를 저장하는 기능 개발
    - publishMessage -> mongo db 저장 
- SSE 추가
- ~~Fcm Token 저장 API 개발~~
    - ~~FCM 토큰은 앱 기준으로 생명주기가 길기 때문에 Redis처럼 TTL을 설정해 만료시키는 것보다 영구 저장이 가능한 MongoDB가 적합하다고 판단했습니다~~

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



