### PR TITLE
BV2-180 (Feat) : 사용자-채팅방 연결 로직 구현

### DIFF
--- a/chat/src/main/java/chat/adapter/input/web/ChatApiController.java
+++ b/chat/src/main/java/chat/adapter/input/web/ChatApiController.java
@@ -1,0 +1,30 @@
+package chat.adapter.input.web;
+
+import chat.adapter.input.web.response.ChatRoomResponse;
+import chat.application.port.input.ChatRoomReaderUseCase;
+import chat.domain.command.ChatRoomReaderCommand;
+import global.annotation.AuthenticatedUser;
+import global.annotation.input.RestAdapter;
+import global.api.Api;
+import global.resolver.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@RestAdapter
+@RequiredArgsConstructor
+public class ChatApiController {
+
+    private final ChatRoomReaderUseCase chatRoomReaderUseCase;
+
+    @GetMapping("/chat-room/{articleId}")
+    public Api<ChatRoomResponse> enterChatRoom(
+        @AuthenticatedUser AuthUser authUser,
+        @PathVariable String articleId
+    ) {
+        String chatRoomId = chatRoomReaderUseCase.getChatRoom(
+            ChatRoomReaderCommand.of(articleId, authUser.getUserId()));
+        return Api.OK(ChatRoomResponse.of(chatRoomId));
+    }
+
+}

--- a/chat/src/main/java/chat/adapter/input/web/response/ChatRoomResponse.java
+++ b/chat/src/main/java/chat/adapter/input/web/response/ChatRoomResponse.java
@@ -1,0 +1,22 @@
+package chat.adapter.input.web.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomResponse {
+
+    private String chatRoomId;
+
+    public static ChatRoomResponse of(String chatRoomId) {
+        return ChatRoomResponse.builder()
+            .chatRoomId(chatRoomId)
+            .build();
+    }
+
+}

--- a/chat/src/main/java/chat/application/ChatConnectionService.java
+++ b/chat/src/main/java/chat/application/ChatConnectionService.java
@@ -1,0 +1,48 @@
+package chat.application;
+
+import chat.application.port.input.ChatConnectionUseCase;
+import chat.application.sse.SseConnectionStore;
+import chat.application.sse.SseEmitterManager;
+import chat.application.sse.UserSseConnection;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatConnectionService implements ChatConnectionUseCase {
+
+    private final SseConnectionStore<String, UserSseConnection> sseConnectionStore;
+    private final SseEmitterManager sseEmitterManager;
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${server.port}")
+    private String serverPort;
+
+    @Override
+    public void connectChatRoom(String userId, String chatRoomId) {
+        sseConnectionStore.saveEmitter(userId, sseEmitterManager.createSseEmitter(userId));
+        redisTemplate.opsForSet().add(userId + ":" + chatRoomId, getServerAddress());
+    }
+
+
+    @Override
+    public void disconnectChatRoom(String userId, String chatRoomId, UserSseConnection connection) {
+        redisTemplate.delete(userId + ":" + chatRoomId);
+        sseConnectionStore.deleteEmitter(connection);
+    }
+
+    private String getServerAddress() {
+        try {
+            return InetAddress.getLocalHost().getHostAddress() + serverPort;
+        } catch (UnknownHostException e) {
+            throw new RuntimeException("Failed to get server address", e);
+        }
+    }
+
+}

--- a/chat/src/main/java/chat/application/ChatConnectionService.java
+++ b/chat/src/main/java/chat/application/ChatConnectionService.java
@@ -6,8 +6,7 @@ import chat.application.sse.SseEmitterManager;
 import chat.application.sse.UserSseConnection;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.HashMap;
-import java.util.Map;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -27,13 +26,14 @@ public class ChatConnectionService implements ChatConnectionUseCase {
     @Override
     public void connectChatRoom(String userId, String chatRoomId) {
         sseConnectionStore.saveEmitter(userId, sseEmitterManager.createSseEmitter(userId));
-        redisTemplate.opsForSet().add(userId + ":" + chatRoomId, getServerAddress());
+        redisTemplate.opsForSet().add(userId, getServerAddress());
+        redisTemplate.expire(userId, Duration.ofHours(1));
     }
 
 
     @Override
-    public void disconnectChatRoom(String userId, String chatRoomId, UserSseConnection connection) {
-        redisTemplate.delete(userId + ":" + chatRoomId);
+    public void disconnectChatRoom(String userId, UserSseConnection connection) {
+        redisTemplate.delete(userId);
         sseConnectionStore.deleteEmitter(connection);
     }
 

--- a/chat/src/main/java/chat/application/ChatRoomCheckService.java
+++ b/chat/src/main/java/chat/application/ChatRoomCheckService.java
@@ -1,6 +1,5 @@
 package chat.application;
 
-import chat.adapter.output.persistence.repository.document.ChatRoomDocument;
 import chat.application.port.input.ChatRoomCheckUseCase;
 import chat.application.port.output.UserChatPersistencePort;
 import java.util.List;
@@ -16,12 +15,9 @@ public class ChatRoomCheckService implements ChatRoomCheckUseCase {
 
     @Override
     public Optional<String> existsChatRoomBy(List<String> chatRoomIdList, String userId) {
-        for (String chatRoomId : chatRoomIdList) {
-            if (userChatPersistencePort.getUserChat(chatRoomId, userId).isPresent()) {
-                return Optional.ofNullable(chatRoomId);
-            }
-        }
-        return Optional.empty();
+        return chatRoomIdList.stream()
+            .filter(chatRoomId -> userChatPersistencePort.getUserChat(chatRoomId, userId).isPresent())
+            .findFirst();
     }
 
 }

--- a/chat/src/main/java/chat/application/ChatRoomReaderService.java
+++ b/chat/src/main/java/chat/application/ChatRoomReaderService.java
@@ -4,11 +4,12 @@ import chat.adapter.output.persistence.repository.document.ChatRoomDocument;
 import chat.application.chatroom.ChatRoom;
 import chat.application.chatroom.ChatRoomGenerator;
 import chat.application.port.input.ChatRoomCheckUseCase;
+import chat.application.port.input.ChatRoomReaderUseCase;
 import chat.application.port.input.UserChatSaveUseCase;
 import chat.application.port.output.ChatRoomPersistencePort;
 import chat.application.userchat.UserChat;
 import chat.application.userchat.UserChatGenerator;
-import chat.domain.command.ChatRoomSaveCommand;
+import chat.domain.command.ChatRoomReaderCommand;
 import chat.domain.dto.ChatRoomSaveForm;
 import chat.domain.dto.UserChatSaveForm;
 import java.util.List;
@@ -20,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ChatRoomReaderService {
+public class ChatRoomReaderService implements ChatRoomReaderUseCase {
 
     private final ChatRoomCheckUseCase chatRoomCheckUseCase;
 
@@ -33,7 +34,7 @@ public class ChatRoomReaderService {
     private final UserChatGenerator userChatGenerator;
 
     @Transactional
-    public String getChatRoom(ChatRoomSaveCommand command) {
+    public String getChatRoom(ChatRoomReaderCommand command) {
 
         // 1. articleId 로 기준 채팅방 조회
         List<String> chatRoomIdList = chatRoomPersistencePort.getChatRoomListBy(command.getArticleId())
@@ -44,7 +45,7 @@ public class ChatRoomReaderService {
             .orElseGet(() -> createNewChatRoom(command));
     }
 
-    private String createNewChatRoom(ChatRoomSaveCommand command) {
+    private String createNewChatRoom(ChatRoomReaderCommand command) {
 
         // 3. ChatRoom 생성
         ChatRoom chatRoom = chatRoomGenerator.createChatRoom(command);

--- a/chat/src/main/java/chat/application/chatroom/AbstractChatRoomGenerator.java
+++ b/chat/src/main/java/chat/application/chatroom/AbstractChatRoomGenerator.java
@@ -3,7 +3,7 @@ package chat.application.chatroom;
 import chat.adapter.output.client.ArticleClient;
 import chat.adapter.output.client.UserClient;
 import chat.adapter.output.client.dto.ArticleFeignInfo;
-import chat.domain.command.ChatRoomSaveCommand;
+import chat.domain.command.ChatRoomReaderCommand;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -15,7 +15,7 @@ public abstract class AbstractChatRoomGenerator {
 
     private final UserClient userClient;
 
-    public final ChatRoom createChatRoom(ChatRoomSaveCommand command) {
+    public final ChatRoom createChatRoom(ChatRoomReaderCommand command) {
 
         ArticleFeignInfo articleBy = articleClient.getArticleBy(command.getArticleId());
 

--- a/chat/src/main/java/chat/application/port/input/ChatConnectionUseCase.java
+++ b/chat/src/main/java/chat/application/port/input/ChatConnectionUseCase.java
@@ -6,6 +6,6 @@ public interface ChatConnectionUseCase {
 
     void connectChatRoom(String userId, String chatRoomId);
 
-    void disconnectChatRoom(String userId, String chatRoomId, UserSseConnection connection);
+    void disconnectChatRoom(String userId, UserSseConnection connection);
 
 }

--- a/chat/src/main/java/chat/application/port/input/ChatConnectionUseCase.java
+++ b/chat/src/main/java/chat/application/port/input/ChatConnectionUseCase.java
@@ -1,0 +1,11 @@
+package chat.application.port.input;
+
+import chat.application.sse.UserSseConnection;
+
+public interface ChatConnectionUseCase {
+
+    void connectChatRoom(String userId, String chatRoomId);
+
+    void disconnectChatRoom(String userId, String chatRoomId, UserSseConnection connection);
+
+}

--- a/chat/src/main/java/chat/application/port/input/ChatRoomReaderUseCase.java
+++ b/chat/src/main/java/chat/application/port/input/ChatRoomReaderUseCase.java
@@ -1,0 +1,9 @@
+package chat.application.port.input;
+
+import chat.domain.command.ChatRoomReaderCommand;
+
+public interface ChatRoomReaderUseCase {
+
+    String getChatRoom(ChatRoomReaderCommand command);
+
+}

--- a/chat/src/main/java/chat/application/userchat/UserChatGenerator.java
+++ b/chat/src/main/java/chat/application/userchat/UserChatGenerator.java
@@ -1,7 +1,7 @@
 package chat.application.userchat;
 
 import chat.adapter.output.client.ArticleClient;
-import chat.domain.command.ChatRoomSaveCommand;
+import chat.domain.command.ChatRoomReaderCommand;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,7 +12,7 @@ public class UserChatGenerator {
 
     private final ArticleClient articleClient;
 
-    public List<UserChat> createUserChat(String chatRoomId, ChatRoomSaveCommand command) {
+    public List<UserChat> createUserChat(String chatRoomId, ChatRoomReaderCommand command) {
 
         String sellerId = articleClient.getArticleBy(command.getArticleId()).getUserId();
 

--- a/chat/src/main/java/chat/domain/command/ChatRoomReaderCommand.java
+++ b/chat/src/main/java/chat/domain/command/ChatRoomReaderCommand.java
@@ -7,14 +7,14 @@ import lombok.Data;
 @Data
 @Builder
 @AllArgsConstructor
-public class ChatRoomSaveCommand {
+public class ChatRoomReaderCommand {
 
     private String articleId;
 
     private String buyerId;
 
-    public static ChatRoomSaveCommand of(String articleId, String buyerId) {
-        return ChatRoomSaveCommand.builder()
+    public static ChatRoomReaderCommand of(String articleId, String buyerId) {
+        return ChatRoomReaderCommand.builder()
             .articleId(articleId)
             .buyerId(buyerId)
             .build();


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

1. ChatConnectionService 개발
2. ChatRoomSaveCommand -> ChatRoomReaderCommand 로 변경
3. ChatApiController 개발


### `sessionId` 대신 `userId:chatRoomId` key 를 사용한 이유
- 사용자 A 가 사용자 B 에게 메시지를 보낸다고 가정할 때, A 는 B 의 접속 정보를 조회해야 합니다. 하지만, `sessionId` 를 `key` 로 사용할 경우 A 는 B의 `sessionId` 를 알 수 없어 조회가 불가능하다고 판단했습니다.

### `userId:chatRoomId` key 조합
- 사용자 A 가 `chat-room-1` 과 `chat-room-2` 에 동시 접속해 있다고 가정하면, `userId` 만 key 로 사용할 경우 A 가 어떤 채팅방에 접속해있는지 알 수 없어 불필요한 push 알림이 전송될 가능성이 존재합니다.
-  반면, `userId:chatRoomId` 를 key 로 사용한 경우, A 가 특정 채팅방에 접속중인지 확인 가능합니다.

### SERVER Address 저장
- Value 값에는 서버 주소를 저장하며, 메시지를 FeignClient 를 통해 전달할 예정
- FeignClient 는 Runtime 시점에 동적으로 URL 을 변경할 수 있는 기능을 제공하므로 스케일아웃 확장에 대응할 수 있을 것으로 보임 (좀 더 알아봐야 함)

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

- 아직 `connectChatRoom` 호출은 구현하지 않았습니다.

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



