### PR TITLE
BV2-133 (Feat) : 중고거래 게시글 조회 시 유저 닉네임, 프로필 이미지 정보 추가

### DIFF
--- a/article/build.gradle
+++ b/article/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0'
     annotationProcessor 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
+    // OpenFeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
     // In-Memory Mongo
     testImplementation 'de.bwaldvogel:mongo-java-server:1.46.0'
 

--- a/article/src/main/java/article/ArticleApplication.java
+++ b/article/src/main/java/article/ArticleApplication.java
@@ -3,8 +3,10 @@ package article;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableDiscoveryClient
+@EnableFeignClients
 @SpringBootApplication(scanBasePackages = {"article", "global", "file"})
 public class ArticleApplication {
 

--- a/article/src/main/java/article/adapter/input/web/response/ArticleInfoResponse.java
+++ b/article/src/main/java/article/adapter/input/web/response/ArticleInfoResponse.java
@@ -1,5 +1,6 @@
 package article.adapter.input.web.response;
 
+import article.adapter.output.client.dto.UserSimpleInfo;
 import article.adapter.output.persistence.enums.ArticleCategory;
 import article.adapter.output.persistence.enums.ArticleStatus;
 import article.adapter.output.persistence.repository.Article;
@@ -31,11 +32,13 @@ public class ArticleInfoResponse {
 
     private ArticleStatus status;
 
-    private String userId;
-
     private List<ArticleImage> imageList;
 
-    public static ArticleInfoResponse of(Article article) {
+    private String nickname;
+
+    private String profileImage;
+
+    public static ArticleInfoResponse of(Article article, UserSimpleInfo userSimpleInfo) {
         return ArticleInfoResponse.builder()
             .id(article.getId())
             .title(article.getTitle())
@@ -44,7 +47,8 @@ public class ArticleInfoResponse {
             .price(article.getPrice())
             .registeredAt(article.getRegisteredAt())
             .status(article.getStatus())
-            .userId(article.getUserId())
+            .nickname(userSimpleInfo.getNickname())
+            .profileImage(userSimpleInfo.getProfileImage())
             .imageList(article.getImageList())
             .build();
     }

--- a/article/src/main/java/article/adapter/output/client/UserClient.java
+++ b/article/src/main/java/article/adapter/output/client/UserClient.java
@@ -1,0 +1,13 @@
+package article.adapter.output.client;
+
+import article.adapter.output.client.dto.UserSimpleInfo;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "baobab-users")
+public interface UserClient {
+
+    @GetMapping("/simple-info")
+    UserSimpleInfo getUserSimpleInfo(@RequestParam("userId") String userId);
+}

--- a/article/src/main/java/article/adapter/output/client/dto/UserSimpleInfo.java
+++ b/article/src/main/java/article/adapter/output/client/dto/UserSimpleInfo.java
@@ -1,0 +1,14 @@
+package article.adapter.output.client.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UserSimpleInfo {
+
+    private String nickname;
+
+    private String profileImage;
+
+}

--- a/article/src/main/java/article/application/ArticleService.java
+++ b/article/src/main/java/article/application/ArticleService.java
@@ -1,6 +1,7 @@
 package article.application;
 
 import article.adapter.input.web.response.ArticleInfoResponse;
+import article.adapter.output.client.UserClient;
 import article.adapter.output.persistence.repository.Article;
 import article.application.port.input.DefaultArticleUseCase;
 import article.application.port.output.ArticlePersistencePort;
@@ -32,6 +33,8 @@ public class ArticleService implements DefaultArticleUseCase {
 
     private final ArticlePersistencePort articlePersistencePort;
 
+    private final UserClient userClient;
+
     @Override
     public boolean saveArticle(ArticleSaveCommand articleSaveCommand) {
         List<ImageMetaData> imageMetaDataList = imageMetaDataUseCase.processImageMetaDataList(
@@ -45,7 +48,9 @@ public class ArticleService implements DefaultArticleUseCase {
     @Override
     public List<ArticleInfoResponse> getArticleList(ArticleSearchCommand articleSearchCommand) {
         List<Article> articles = articlePersistencePort.getArticleList(articleSearchCommand);
-        return articles.stream().map(ArticleInfoResponse::of).toList();
+        return articles.stream().map(article ->
+            ArticleInfoResponse.of(article, userClient.getUserSimpleInfo(article.getUserId()))
+        ).toList();
     }
 
     @Override

--- a/user/src/main/java/user/adapter/input/web/UserOpenApiController.java
+++ b/user/src/main/java/user/adapter/input/web/UserOpenApiController.java
@@ -5,6 +5,7 @@ import global.api.Api;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -13,6 +14,7 @@ import user.adapter.input.web.request.DuplicationEmailRequest;
 import user.adapter.input.web.request.DuplicationNickNameRequest;
 import user.adapter.input.web.request.UserLoginRequest;
 import user.adapter.input.web.request.UserRegisterRequest;
+import user.adapter.input.web.response.SimpleUserInfoResponse;
 import user.adapter.input.web.response.TokenResponse;
 import user.adapter.input.web.response.UserRegisterResponse;
 import user.application.port.input.ReIssueAccessTokenUseCase;
@@ -22,6 +24,7 @@ import user.application.port.input.UserRegisterUseCase;
 import user.core.common.annotation.DupleCheck;
 import user.domain.command.TokenCommand;
 import user.domain.command.UserLoginCommand;
+import user.domain.command.UserReaderCommand;
 import user.domain.command.UserRegisterCommand;
 import user.security.jwt.model.TokenDto;
 
@@ -77,9 +80,10 @@ public class UserOpenApiController {
         return Api.OK(true);
     }
 
-    @GetMapping("/nickname")
-    String getNickname(@RequestParam("userId") String userId){
-        return userReaderUseCase.getUserNickname(userId);
+    @GetMapping("/simple-info")
+    public SimpleUserInfoResponse getSimpleUserInfo(@RequestParam String userId) {
+        UserReaderCommand userInfo = userReaderUseCase.getUserInfoWithUnregisteredNickname(userId);
+        return SimpleUserInfoResponse.toResponse(userInfo);
     }
 
 }

--- a/user/src/main/java/user/adapter/input/web/response/SimpleUserInfoResponse.java
+++ b/user/src/main/java/user/adapter/input/web/response/SimpleUserInfoResponse.java
@@ -1,0 +1,23 @@
+package user.adapter.input.web.response;
+
+import lombok.Builder;
+import lombok.Data;
+import user.domain.command.UserReaderCommand;
+import user.domain.dto.ProfileImage;
+
+@Data
+@Builder
+public class SimpleUserInfoResponse {
+
+    private String nickname;
+
+    private ProfileImage profileImage;
+
+    public static SimpleUserInfoResponse toResponse(UserReaderCommand userReaderCommand) {
+        return SimpleUserInfoResponse.builder()
+            .nickname(userReaderCommand.getNickName())
+            .profileImage(userReaderCommand.getProfileImage())
+            .build();
+    }
+
+}

--- a/user/src/main/java/user/application/UserReaderService.java
+++ b/user/src/main/java/user/application/UserReaderService.java
@@ -22,12 +22,14 @@ public class UserReaderService implements UserReaderUseCase {
     }
 
     @Override
-    public String getUserNickname(String userId) {
+    public UserReaderCommand getUserInfoWithUnregisteredNickname(String userId) {
         UserReaderCommand user = userPersistencePort.getUserInfo(userId);
+
         if (user.getStatus().equals(UserStatus.UNREGISTERED)) {
-            return UNREGISTERED_USER_NICKNAME;
+            user.setNickName(UNREGISTERED_USER_NICKNAME);
         }
-        return user.getNickName();
+
+        return user;
     }
 
 }

--- a/user/src/main/java/user/application/port/input/UserReaderUseCase.java
+++ b/user/src/main/java/user/application/port/input/UserReaderUseCase.java
@@ -6,6 +6,6 @@ public interface UserReaderUseCase {
 
     UserReaderCommand getUserInfoBy(String userId);
 
-    String getUserNickname(String userId);
+    UserReaderCommand getUserInfoWithUnregisteredNickname(String userId);
 
 }


### PR DESCRIPTION
## #️⃣ Issue Number
N/A

## 📝 요약(Summary)
- iOS의 요청에 따라 유저 닉네임, 프로필 이미지 정보 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
N/A

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)