### PR TITLE
BV2-199 (!HOTFIX) : Interceptor 가 userId 없이 요청을 통과시키는 문제 해결

### DIFF
--- a/article/src/main/java/article/core/config/web/WebMvcConfig.java
+++ b/article/src/main/java/article/core/config/web/WebMvcConfig.java
@@ -4,11 +4,7 @@ import global.interceptor.AuthorizationInterceptor;
 import global.resolver.AuthenticatedUserResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -21,7 +17,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final List<String> WHITE_LIST = List.of(
         "/list",
-        "/article/{articleId}"
+        "/article/{articleId}",
+        "/simple-info"
     );
 
     @Override

--- a/chat/src/main/java/chat/core/config/web/WebMvcConfig.java
+++ b/chat/src/main/java/chat/core/config/web/WebMvcConfig.java
@@ -15,7 +15,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final AuthorizationInterceptor authorizationInterceptor;
 
-    private final List<String> WHITE_LIST = List.of();
+    private final List<String> WHITE_LIST = List.of(
+        "/feign/message"
+    );
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/global/src/main/java/global/interceptor/AuthorizationInterceptor.java
+++ b/global/src/main/java/global/interceptor/AuthorizationInterceptor.java
@@ -1,6 +1,5 @@
 package global.interceptor;
 
-import global.errorcode.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Objects;
@@ -31,11 +30,13 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
         // Gateway 에서 전달한 Header 추출
         String userId = request.getHeader(X_USER_ID);
 
-        if (userId != null) {
-            RequestAttributes requestContext = Objects.requireNonNull(
-                RequestContextHolder.getRequestAttributes());
-            requestContext.setAttribute(X_USER_ID, userId, RequestAttributes.SCOPE_REQUEST);
+        if (userId == null) {
+            throw new RuntimeException("userId header 가 존재하지 않습니다.");
         }
+
+        RequestAttributes requestContext = Objects.requireNonNull(
+            RequestContextHolder.getRequestAttributes());
+        requestContext.setAttribute(X_USER_ID, userId, RequestAttributes.SCOPE_REQUEST);
 
         return true;
     }

--- a/user/src/main/java/user/adapter/input/web/UserOpenApiController.java
+++ b/user/src/main/java/user/adapter/input/web/UserOpenApiController.java
@@ -5,7 +5,6 @@ import global.api.Api;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/user/src/main/java/user/core/config/web/WebMvcConfig.java
+++ b/user/src/main/java/user/core/config/web/WebMvcConfig.java
@@ -26,7 +26,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
         "/reissue",
         "/duplication/email",
         "/duplication/nickname",
-        "/validation"
+        "/validation",
+        "/simple-info"
     );
 
     @Override


### PR DESCRIPTION

## #️⃣ Issue Number
N/A
## 📝 요약(Summary)

- 기존 Interceptor 로직에서 WHITE_LIST 적용이 제대로 되지 않았던 문제를 해결

> `open-api` 리소스를 실수로 `WHITE_LIST`에 등록하지 않아, Interceptor가 실행될 경우 `userId` 헤더가 없는 요청도 통과되는 문제가 있었습니다.  
> 이로 인해 `userId`가 없어 예외가 발생해야 하지만, 정상적으로 차단되지 않는 문제를 해결하였습니다.


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



