### PR TITLE
BV2-211 (Fix) : 이미지 업로드 지연 개선

### DIFF
--- a/file/build.gradle
+++ b/file/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     // Micrometer
     implementation 'io.micrometer:micrometer-core'
 
+    // thumbnailator
+    implementation 'net.coobird:thumbnailator:0.4.20'
+
     implementation project(":global")
 
 }

--- a/file/build.gradle
+++ b/file/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // Aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+    // Micrometer
+    implementation 'io.micrometer:micrometer-core'
+
     implementation project(":global")
 
 }

--- a/file/src/main/java/file/adapter/output/LocalFileStorageAdapter.java
+++ b/file/src/main/java/file/adapter/output/LocalFileStorageAdapter.java
@@ -48,12 +48,21 @@ public class LocalFileStorageAdapter implements FileDirStoragePort {
         createDirectory(uploadDir);
         Path filePath = createFilePath(imageFile);
 
+        // TODO: usdz 확장자 불필요 시 코드 수정 필요
+        // 파일이 usdz 확장자일 시 jpg 포맷 설정 제외
         try {
-            Thumbnails.of(imageFile.getInputStream())
-                    .size(600, 600)
-                    .outputFormat(OUTPUT_FORMAT)
-                    .outputQuality(0.8)
-                    .toFile(new File(filePath.toString()));
+            if (FileUtils.getExtension(filePath.getFileName().toString()).equals(".usdz")) {
+                Thumbnails.of(imageFile.getInputStream())
+                        .size(600, 600)
+                        .outputFormat(OUTPUT_FORMAT)
+                        .outputQuality(0.8)
+                        .toFile(new File(filePath.toString()));
+            } else {
+                Thumbnails.of(imageFile.getInputStream())
+                        .size(600, 600)
+                        .outputQuality(0.8)
+                        .toFile(new File(filePath.toString()));
+            }
         } catch (Exception e) {
             throw new ImageStorageException(ImageErrorCode.IMAGE_UPLOAD_ERROR, e);
         } finally {
@@ -80,10 +89,16 @@ public class LocalFileStorageAdapter implements FileDirStoragePort {
 
     private Path createFilePath(MultipartFile file) {
         String fileName = StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
-//        String extension = FileUtils.getExtension(fileName);
+        // TODO: usdz 확장자 불필요 시 코드 수정 필요
+        String extension = FileUtils.getExtension(fileName);
+
+        // usdz 확장자 압축 포맷 변경 제외
+        if (!extension.equals(".usdz"))
+            extension = "." + OUTPUT_FORMAT;
+
         String serverName = UUID.randomUUID().toString();
 
-        return Paths.get(uploadDir, serverName + "." + OUTPUT_FORMAT);
+        return Paths.get(uploadDir, serverName + "." + extension);
     }
 
     @Override

--- a/file/src/main/java/file/adapter/output/LocalFileStorageAdapter.java
+++ b/file/src/main/java/file/adapter/output/LocalFileStorageAdapter.java
@@ -6,6 +6,7 @@ import file.core.common.error.ImageErrorCode;
 import file.core.common.exception.image.ImageStorageException;
 import global.annotation.output.PersistenceAdapter;
 import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,6 +33,24 @@ public class LocalFileStorageAdapter implements FileDirStoragePort {
 
         try {
             Files.copy(imageFile.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            throw new ImageStorageException(ImageErrorCode.IMAGE_UPLOAD_ERROR, e);
+        } finally {
+            logImageUploadStatus(filePath);
+        }
+
+        return filePath;
+    }
+
+    @Override
+    public Path resizeAndStore(MultipartFile imageFile) {
+        createDirectory(uploadDir);
+        Path filePath = createFilePath(imageFile);
+
+        try {
+            Thumbnails.of(imageFile.getInputStream())
+                    .size(300, 300)
+                    .toFile(new File(filePath.toString()));
         } catch (Exception e) {
             throw new ImageStorageException(ImageErrorCode.IMAGE_UPLOAD_ERROR, e);
         } finally {

--- a/file/src/main/java/file/adapter/output/LocalFileStorageAdapter.java
+++ b/file/src/main/java/file/adapter/output/LocalFileStorageAdapter.java
@@ -25,6 +25,7 @@ public class LocalFileStorageAdapter implements FileDirStoragePort {
 
     @Value("${file.upload-dir}")
     private String uploadDir;
+    private static final String OUTPUT_FORMAT = "jpg";
 
     @Override
     public Path store(MultipartFile imageFile) {
@@ -49,7 +50,9 @@ public class LocalFileStorageAdapter implements FileDirStoragePort {
 
         try {
             Thumbnails.of(imageFile.getInputStream())
-                    .size(300, 300)
+                    .size(600, 600)
+                    .outputFormat(OUTPUT_FORMAT)
+                    .outputQuality(0.8)
                     .toFile(new File(filePath.toString()));
         } catch (Exception e) {
             throw new ImageStorageException(ImageErrorCode.IMAGE_UPLOAD_ERROR, e);
@@ -77,10 +80,10 @@ public class LocalFileStorageAdapter implements FileDirStoragePort {
 
     private Path createFilePath(MultipartFile file) {
         String fileName = StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
-        String extension = FileUtils.getExtension(fileName);
+//        String extension = FileUtils.getExtension(fileName);
         String serverName = UUID.randomUUID().toString();
 
-        return Paths.get(uploadDir, serverName + extension);
+        return Paths.get(uploadDir, serverName + "." + OUTPUT_FORMAT);
     }
 
     @Override

--- a/file/src/main/java/file/application/port/output/FileDirStoragePort.java
+++ b/file/src/main/java/file/application/port/output/FileDirStoragePort.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 
 public interface FileDirStoragePort {
     Path store(MultipartFile imageFile);
+    Path resizeAndStore(MultipartFile imageFile);
     void delete(Path filePath);
     boolean isExist(Path filePath);
 }

--- a/file/src/main/java/file/core/LocalFileStorageService.java
+++ b/file/src/main/java/file/core/LocalFileStorageService.java
@@ -1,6 +1,7 @@
 package file.core;
 
 import file.application.port.output.FileDirStoragePort;
+import file.core.common.annotation.TrackTime;
 import file.core.common.error.ImageErrorCode;
 import file.core.common.exception.image.ImageStorageException;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ public class LocalFileStorageService {
 
     private final FileDirStoragePort filedirStoragePort;
 
+    @TrackTime
     public Path uploadImage(MultipartFile file) {
         return filedirStoragePort.resizeAndStore(file);
     }

--- a/file/src/main/java/file/core/LocalFileStorageService.java
+++ b/file/src/main/java/file/core/LocalFileStorageService.java
@@ -16,7 +16,7 @@ public class LocalFileStorageService {
     private final FileDirStoragePort filedirStoragePort;
 
     public Path uploadImage(MultipartFile file) {
-        return filedirStoragePort.store(file);
+        return filedirStoragePort.resizeAndStore(file);
     }
 
     public void deleteImage(Path filePath) {

--- a/file/src/main/java/file/core/aop/ImageUploadMetricsAspect.java
+++ b/file/src/main/java/file/core/aop/ImageUploadMetricsAspect.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
@@ -14,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@ConditionalOnProperty(name = "timing.enabled", havingValue = "true")
 public class ImageUploadMetricsAspect {
 
     private final MeterRegistry meterRegistry;

--- a/file/src/main/java/file/core/aop/ImageUploadMetricsAspect.java
+++ b/file/src/main/java/file/core/aop/ImageUploadMetricsAspect.java
@@ -1,0 +1,39 @@
+package file.core.aop;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ImageUploadMetricsAspect {
+
+    private final MeterRegistry meterRegistry;
+
+    @Around("execution(* file.application.port.output.FileDirStoragePort.store(..))")
+    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            long start = System.currentTimeMillis();
+            Object result = joinPoint.proceed();
+            long end = System.currentTimeMillis();
+
+            long uploadTime = end - start;
+            log.info("image.upload.time = {}", uploadTime);
+
+            meterRegistry.timer("image.upload.time").record(uploadTime, TimeUnit.MILLISECONDS);
+
+            return result;
+        }
+        catch (Throwable t) {
+            throw new Exception(t);
+        }
+    }
+}

--- a/file/src/main/java/file/core/aop/ImageUploadMetricsAspect.java
+++ b/file/src/main/java/file/core/aop/ImageUploadMetricsAspect.java
@@ -15,12 +15,13 @@ import java.util.concurrent.TimeUnit;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+// aop 수동 활성을 위한 어노테이션
 @ConditionalOnProperty(name = "timing.enabled", havingValue = "true")
 public class ImageUploadMetricsAspect {
 
     private final MeterRegistry meterRegistry;
 
-    @Around("execution(* file.application.port.output.FileDirStoragePort.store(..))")
+    @Around("@annotation(file.core.common.annotation.TrackTime)")
     public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
         try {
             long start = System.currentTimeMillis();

--- a/file/src/main/java/file/core/common/annotation/TrackTime.java
+++ b/file/src/main/java/file/core/common/annotation/TrackTime.java
@@ -1,0 +1,11 @@
+package file.core.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackTime {
+}

--- a/file/src/main/resources/application-dev.yaml
+++ b/file/src/main/resources/application-dev.yaml
@@ -62,5 +62,6 @@ url:
 cipher:
   key: ${CIPHER_KEY}
 
+# aop 수동 활성을 위한 옵션
 timing:
   enabled: false

--- a/file/src/main/resources/application-dev.yaml
+++ b/file/src/main/resources/application-dev.yaml
@@ -61,3 +61,6 @@ url:
 
 cipher:
   key: ${CIPHER_KEY}
+
+timing:
+  enabled: false

--- a/file/src/main/resources/application-local.yaml
+++ b/file/src/main/resources/application-local.yaml
@@ -62,5 +62,6 @@ url:
 cipher:
   key: ${CIPHER_KEY}
 
+# aop 수동 활성을 위한 옵션
 timing:
   enabled: false

--- a/file/src/main/resources/application-local.yaml
+++ b/file/src/main/resources/application-local.yaml
@@ -61,3 +61,6 @@ url:
 
 cipher:
   key: ${CIPHER_KEY}
+
+timing:
+  enabled: false


### PR DESCRIPTION
## #️⃣ Issue Number

BV2-211 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 이미지 업로드 시간 측정 aop 추가 (수동으로 활성화)
- 이미지 리사이징 및 압축을 통해 브라우저에서 콘텐츠 다운로드 최적화
- 이미지 압축 시 jpg로 포맷을 설정해 효율적인 압축 수행
- usdz 확장자 압축 포맷 설정 제외

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



