### PR TITLE
BV2-244 (Feat) : ArticleInfoResponse 에 isMine 필드 추가

### DIFF
--- a/article/src/main/java/article/adapter/input/web/ArticleApiController.java
+++ b/article/src/main/java/article/adapter/input/web/ArticleApiController.java
@@ -59,7 +59,7 @@ public class ArticleApiController {
         return Api.OK(saveArticleUseCase.saveArticle(command));
     }
 
-    @GetMapping({"/list","/my-articles","/article/{articleId}"})
+    @GetMapping({"/list","/article/{articleId}", "/auth-list", "/auth-article/{articleId}"})
     public Api<List<ArticleInfoResponse>> getAllArticles(
         @PathVariable(required = false) String articleId,
         @ModelAttribute ArticleSearchCondition condition,
@@ -72,11 +72,19 @@ public class ArticleApiController {
             condition.setArticleId(articleId);
         }
 
-        if(authUser != null) {
-            condition.setUserId(authUser.getUserId());
-        }
+        String userId = authUser != null ? authUser.getUserId() : null;
+        return Api.OK(getArticleUseCase.getArticleList(ArticleSearchCommand.of(condition), userId));
+    }
 
-        return Api.OK(getArticleUseCase.getArticleList(ArticleSearchCommand.of(condition)));
+    @GetMapping("/my-articles")
+    public Api<List<ArticleInfoResponse>> getMyArticles(
+        @ModelAttribute ArticleSearchCondition condition,
+        @AuthenticatedUser AuthUser authUser,
+        Pageable pageable) {
+
+        condition.setPageable(pageable);
+        condition.setUserId(authUser.getUserId());
+        return Api.OK(getArticleUseCase.getArticleList(ArticleSearchCommand.of(condition), authUser.getUserId()));
     }
 
     @PostMapping("/update")

--- a/article/src/main/java/article/adapter/input/web/response/ArticleInfoResponse.java
+++ b/article/src/main/java/article/adapter/input/web/response/ArticleInfoResponse.java
@@ -38,7 +38,13 @@ public class ArticleInfoResponse {
 
     private String profileImageUrl;
 
-    public static ArticleInfoResponse of(Article article, UserSimpleInfo userSimpleInfo) {
+    private Boolean isMine;
+
+    public static ArticleInfoResponse of(
+        Article article,
+        UserSimpleInfo userSimpleInfo,
+        Boolean isMine
+    ) {
         return ArticleInfoResponse.builder()
             .id(article.getId())
             .title(article.getTitle())
@@ -50,6 +56,7 @@ public class ArticleInfoResponse {
             .nickname(userSimpleInfo.getNickname())
             .profileImageUrl(userSimpleInfo.getProfileImageUrl())
             .imageList(article.getImageList())
+            .isMine(isMine)
             .build();
     }
 

--- a/article/src/main/java/article/application/ArticleService.java
+++ b/article/src/main/java/article/application/ArticleService.java
@@ -47,11 +47,16 @@ public class ArticleService implements DefaultArticleUseCase {
     }
 
     @Override
-    public List<ArticleInfoResponse> getArticleList(ArticleSearchCommand articleSearchCommand) {
-        List<Article> articles = articlePersistencePort.getArticleList(articleSearchCommand);
-        return articles.stream().map(article ->
-            ArticleInfoResponse.of(article, userClient.getUserSimpleInfo(article.getUserId()))
-        ).toList();
+    public List<ArticleInfoResponse> getArticleList(ArticleSearchCommand command, String userId) {
+        List<Article> articles = articlePersistencePort.getArticleList(command);
+
+        return articles.stream()
+            .map(article -> {
+                boolean isMine = userId != null && userId.equals(article.getUserId());
+                return ArticleInfoResponse.of(article,
+                    userClient.getUserSimpleInfo(article.getUserId()), isMine);
+            })
+            .toList();
     }
 
     @Override

--- a/article/src/main/java/article/application/port/input/GetArticleUseCase.java
+++ b/article/src/main/java/article/application/port/input/GetArticleUseCase.java
@@ -17,7 +17,7 @@ public interface GetArticleUseCase {
      * @param articleSearchCommand Article Search Condition
      * @return ArticleInfoResponse List
      */
-    List<ArticleInfoResponse> getArticleList(ArticleSearchCommand articleSearchCommand);
+    List<ArticleInfoResponse> getArticleList(ArticleSearchCommand articleSearchCommand, String userId);
 
     ArticleFeignResponse getArticleBy(String articleId);
 


### PR DESCRIPTION

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

- 기존 `/open-api/list`, `/open-api/article/{articleId}` 경로는 인증 없이 접근 가능한 public API입니다.  
하지만 게시글 응답에 `isMine` 여부를 포함하려면 로그인한 사용자의 ID가 필요하기 때문에,  
인증이 필요한 경로(`/auth-list`, `/auth-article/{articleId}`)를 별도로 추가하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



