### PR TITLE
BV2-248 (Feat) : 채팅 응답메시지에 messageId, nickname, profileImageUrl 필드 추가

### DIFF
--- a/chat/src/main/java/chat/application/MessageProducerService.java
+++ b/chat/src/main/java/chat/application/MessageProducerService.java
@@ -1,5 +1,6 @@
 package chat.application;
 
+import chat.adapter.output.client.UserClient;
 import chat.adapter.output.persistence.repository.document.MessageDocument;
 import chat.application.port.input.MessageProducerUseCase;
 import chat.application.port.output.ChatMessagePersistencePort;
@@ -9,9 +10,9 @@ import chat.core.common.exception.chatroom.ChatRoomNotFoundException;
 import chat.domain.ChatMessage;
 import chat.domain.command.ChatMessageCommand;
 import chat.domain.dto.ChatMessageSaveForm;
+import chat.domain.dto.UserSimpleInfo;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,43 +24,57 @@ public class MessageProducerService implements MessageProducerUseCase {
 
     private final ChatRoomCheckService chatRoomCheckService;
     private final UserChatReaderService userChatReaderService;
+    private final UserChatUpdateService userChatUpdateService;
 
     private final KafkaProducerPort kafkaProducerPort;
     private final ChatMessagePersistencePort chatMessagePersistencePort;
 
+    private final UserClient userClient;
+
     private static final String TOPIC_NAME = "chatMessage";
-    private final UserChatUpdateService userChatUpdateService;
 
     @Override
     public boolean produceMessage(ChatMessageCommand command) {
 
-        String chatRoomId = chatRoomCheckService.existsChatRoomBy(List.of(command.getChatRoomId()),
-                command.getUserId())
-            .orElseThrow(() -> new ChatRoomNotFoundException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        String chatRoomId = validateChatRoom(command);
 
         MessageDocument savedMessage = chatMessagePersistencePort.saveMessage(
             ChatMessageSaveForm.of(command));
 
         // receiverID List 조회
-        List<String> receiverIdList = userChatReaderService.getUserChatsExcludingSender(
-            savedMessage.getChatRoomId(), command.getUserId());
+        List<String> receiverIdList = getReceiverIdList(savedMessage, command);
 
         log.info("수신 대상 ID : {}", receiverIdList);
 
+        UserSimpleInfo userSimpleInfo = userClient.getUserSimpleInfo(command.getUserId());
         kafkaProducerPort.send(TOPIC_NAME,
-            ChatMessage.of(savedMessage, command.getUserId(), receiverIdList));
+            ChatMessage.of(savedMessage, command.getUserId(), userSimpleInfo, receiverIdList));
 
-        // receiverIdList 에 sender 추가
-        List<String> userIdList = new ArrayList<>(receiverIdList);
-        userIdList.add(command.getUserId());
-
-        log.info("채팅방 날짜 업데이트");
-        // 마지막 채팅방 날짜 업데이트
-        userChatUpdateService.updateLastChatAt(
-            chatRoomId, userIdList, savedMessage.getSentAt()
-        );
+        updateLastChatAt(chatRoomId, receiverIdList, command, savedMessage);
 
         return true;
+    }
+
+    private String validateChatRoom(ChatMessageCommand command) {
+        return chatRoomCheckService.existsChatRoomBy(List.of(command.getChatRoomId()),
+                command.getUserId())
+            .orElseThrow(() -> new ChatRoomNotFoundException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private List<String> getReceiverIdList(MessageDocument savedMessage,
+        ChatMessageCommand command) {
+        List<String> receiverIdList = userChatReaderService.getUserChatsExcludingSender(
+            savedMessage.getChatRoomId(), command.getUserId());
+        log.info("수신 대상 ID : {}", receiverIdList);
+        return receiverIdList;
+    }
+
+    private void updateLastChatAt(String chatRoomId, List<String> receiverIdList,
+        ChatMessageCommand command, MessageDocument savedMessage) {
+        List<String> userIdList = new ArrayList<>(receiverIdList);
+        userIdList.add(command.getUserId());
+        log.info("채팅방 날짜 업데이트");
+        userChatUpdateService.updateLastChatAt(chatRoomId, userIdList, savedMessage.getSentAt());
     }
 
 }

--- a/chat/src/main/java/chat/domain/ChatMessage.java
+++ b/chat/src/main/java/chat/domain/ChatMessage.java
@@ -2,6 +2,7 @@ package chat.domain;
 
 import chat.adapter.output.persistence.enums.MessageType;
 import chat.adapter.output.persistence.repository.document.MessageDocument;
+import chat.domain.dto.UserSimpleInfo;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -14,6 +15,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatMessage {
+
+    // message id
+    private String id;
 
     private String senderId;
 
@@ -29,8 +33,18 @@ public class ChatMessage {
 
     private String chatRoomId;
 
-    public static ChatMessage of(MessageDocument document, String userId, List<String> receiverIdList) {
+    private String nickname;
+
+    private String profileImageUrl;
+
+    public static ChatMessage of(
+        MessageDocument document,
+        String userId,
+        UserSimpleInfo userSimpleInfo,
+        List<String> receiverIdList
+    ) {
         return ChatMessage.builder()
+            .id(document.getId())
             .senderId(userId)
             .receiverIdList(receiverIdList)
             .message(document.getMessage())
@@ -38,6 +52,8 @@ public class ChatMessage {
             .sentAt(document.getSentAt())
             .isRead(document.getIsRead())
             .chatRoomId(document.getChatRoomId())
+            .nickname(userSimpleInfo.getNickname())
+            .profileImageUrl(userSimpleInfo.getProfileImageUrl())
             .build();
     }
 


### PR DESCRIPTION

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

ChatMessage 응답에 `message id`, `nickname`, `profileImageUrl` 필드 추가되었습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



